### PR TITLE
Use Zig 0.10.0 release to compile libsodium

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM wasmedge/wasmedge:latest
 
 # args
-ARG ZIG=zig-linux-x86_64-0.10.0-dev.430+35423b005.tar.xz
+ARG ZIG=zig-linux-x86_64-0.10.0.tar.xz
 
 WORKDIR /root
 


### PR DESCRIPTION
Instead of a snapshot, since 0.10.0 has been released.