### PR TITLE
v0.0.2: upgrade zig version

### DIFF
--- a/.github/workflows/branch-main.yml
+++ b/.github/workflows/branch-main.yml
@@ -6,9 +6,9 @@ jobs:
     steps:
       - name: Install Node.js
         run: |
-          wget -O- https://nodejs.org/dist/v16.15.0/node-v16.15.0-linux-x64.tar.xz | tar -Jx
+          wget -O- https://nodejs.org/dist/v14.21.3/node-v14.21.3-linux-x64.tar.xz | tar -Jx
       - name: Self-testing
         uses: second-state/wasmedge-actions-libsodium-tests@main
         with:
-          path: node-v16.15.0-linux-x64/bin
+          path: node-v14.21.3-linux-x64/bin
           wasi-runtime: node

--- a/.github/workflows/v0.0.1.yml
+++ b/.github/workflows/v0.0.1.yml
@@ -6,9 +6,9 @@ jobs:
     steps:
       - name: Install Node.js
         run: |
-          wget -O- https://nodejs.org/dist/v16.15.0/node-v16.15.0-linux-x64.tar.xz | tar -Jx
+          wget -O- https://nodejs.org/dist/v14.21.3/node-v14.21.3-linux-x64.tar.xz | tar -Jx
       - name: Self-testing v0.0.1
         uses: second-state/wasmedge-actions-libsodium-tests@v0.0.1
         with:
-          path: node-v16.15.0-linux-x64/bin
+          path: node-v14.21.3-linux-x64/bin
           wasi-runtime: node

--- a/.github/workflows/v0.0.2.yml
+++ b/.github/workflows/v0.0.2.yml
@@ -1,0 +1,27 @@
+on: [push]
+
+jobs:
+  self_testing_node:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Node.js
+        run: |
+          wget -O- https://nodejs.org/dist/v14.21.3/node-v14.21.3-linux-x64.tar.xz | tar -Jx
+      - name: Self-testing v0.0.2
+        uses: second-state/wasmedge-actions-libsodium-tests@v0.0.2
+        with:
+          path: node-v14.21.3-linux-x64/bin
+          wasi-runtime: node
+
+  self_testing_wasmedge:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install WasmEdge
+        run: |
+          mkdir wasmedge-0.12.1
+          curl -sSf https://raw.githubusercontent.com/WasmEdge/WasmEdge/master/utils/install.sh | bash -s -- -p wasmedge-0.12.1 -v '0.12.1'
+      - name: Self-testing v0.0.2
+        uses: second-state/wasmedge-actions-libsodium-tests@v0.0.2
+        with:
+          path: wasmedge-0.12.1/bin
+          wasi-runtime: wasmedge

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,13 @@
 FROM wasmedge/wasmedge:latest
 
 # args
-ARG ZIG=zig-linux-x86_64-0.10.0.tar.xz
+ARG ZIG_VERSION=0.10.1
+ARG ZIG=zig-linux-x86_64-$ZIG_VERSION.tar.xz
 
 WORKDIR /root
 
 # dependencies: Zig
-RUN wget https://ziglang.org/builds/$ZIG
+RUN wget https://ziglang.org/download/$ZIG_VERSION/$ZIG
 RUN mkdir -p .zig \
     && tar xvf $ZIG -C .zig --strip-components=1
 RUN rm $ZIG


### PR DESCRIPTION
`v0.0.0` - empty test, should pass
`v0.0.1` - failing because
  - download url for Zig no longer work
  - libsodium added `--experimental-wasm-bigint` for node (see [wasi-test-wrapper.sh](https://github.com/jedisct1/libsodium/blob/stable/test/default/wasi-test-wrapper.sh)), which works on 14.x but not 16.x

`v0.0.2` - should pass
`branch-main` - should pass after PR merged